### PR TITLE
Switch to using trestle-settings as settings name

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Theme functionality
+ * Theme functionality.
  *
  * @since  1.0.0
  *
@@ -12,31 +12,31 @@
  * Required Files
 ===========================================*/
 
-// Theme functions
+// Theme functions.
 require_once dirname( __FILE__ ) . '/includes/functions/theme-functions.php';
 
-// Admin functionality
+// Admin functionality.
 require_once dirname( __FILE__ ) . '/includes/admin/admin.php';
 
-// Customizer controls
+// Customizer controls.
 require_once dirname( __FILE__ ) . '/includes/admin/customizer.php';
 
-// Shortcodes
+// Shortcodes.
 require_once dirname( __FILE__ ) . '/includes/shortcodes/shortcodes.php';
 
-// Additional sidebars
+// Additional sidebars.
 require_once dirname( __FILE__ ) . '/includes/widget-areas/widget-areas.php';
 
-// Plugin activation class
+// Plugin activation class.
 require_once dirname( __FILE__ ) . '/includes/classes/class-tgm-plugin-activation.php';
 
-// Better Font Awesome Library
+// Better Font Awesome Library.
 require_once dirname( __FILE__ ) . '/lib/better-font-awesome-library/better-font-awesome-library.php';
 
 
-add_action( 'genesis_setup' ,'trestle_theme_setup', 15 );
+add_action( 'genesis_setup', 'trestle_theme_setup', 15 );
 /**
- * Initialize Trestle
+ * Initialize Trestle.
  *
  * @since  1.0.0
  */
@@ -46,21 +46,25 @@ function trestle_theme_setup() {
 	 * Theme Setup
 	===========================================*/
 
-	// Child theme definitions (do not remove)
+	// Child theme definitions (do not remove).
 	define( 'CHILD_THEME_NAME', 'Trestle' );
 	define( 'CHILD_THEME_URL', 'http://demo.mightyminnow.com/theme/trestle/' );
 	define( 'CHILD_THEME_VERSION', '1.2.0' );
+	define( 'TRESTLE_SETTINGS_FIELD', 'trestle-settings' );
 
-	// Load theme text domain
+	// Setup default theme settings.
+	trestle_settings_defaults();
+
+	// Load theme text domain.
 	load_theme_textdomain( 'trestle', get_stylesheet_directory() . '/languages' );
 
-	// Add HTML5 markup structure
+	// Add HTML5 markup structure.
 	add_theme_support( 'html5' );
 
-	// Add viewport meta tag for mobile browsers
+	// Add viewport meta tag for mobile browsers.
 	add_theme_support( 'genesis-responsive-viewport' );
 
-	// Add support for footer widgets if specified in Trestle settings
-	$trestle_footer_widgets_number = esc_attr( genesis_get_option( 'trestle_footer_widgets_number' ) );
+	// Add support for footer widgets if specified in Trestle settings.
+	$trestle_footer_widgets_number = esc_attr( genesis_get_option( 'footer_widgets_number', 'trestle-settings' ) );
 	add_theme_support( 'genesis-footer-widgets', $trestle_footer_widgets_number );
 }

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -36,7 +36,7 @@ function trestle_settings_defaults() {
 		'logo_url_mobile'       => '',
 		'favicon_url' 			=> '',
 		'nav_primary_location'  => 'full',
-		'custom_nav_extras_text' => '',
+		'search_in_nav' 		=> '',
 		'read_more_text'        => __( 'Read&nbsp;More&nbsp;&raquo;', 'trestle' ),
 		'revisions_number'      => 3,
 		'footer_widgets_number' => 3,

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -31,19 +31,19 @@ function trestle_settings_defaults() {
 
 	// Trestle default key/value pairs.
 	$trestle_defaults = array(
-		'layout'                => 'solid',
-		'logo_url'              => '',
-		'logo_url_mobile'       => '',
-		'favicon_url' 			=> '',
-		'nav_primary_location'  => 'full',
-		'search_in_nav' 		=> '',
-		'read_more_text'        => __( 'Read&nbsp;More&nbsp;&raquo;', 'trestle' ),
-		'revisions_number'      => 3,
-		'footer_widgets_number' => 3,
-		'external_link_icons'   => 0,
-		'email_link_icons' 		=> 0,
-		'pdf_link_icons' 		=> 0,
-		'doc_link_icons' 		=> 0,
+		'layout'				=> 'solid',
+		'logo_url'				=> '',
+		'logo_url_mobile'		=> '',
+		'favicon_url'			=> '',
+		'nav_primary_location'	=> 'full',
+		'search_in_nav'			=> '',
+		'read_more_text'		=> __( 'Read&nbsp;More&nbsp;&raquo;', 'trestle' ),
+		'revisions_number'		=> 3,
+		'footer_widgets_number'	=> 3,
+		'external_link_icons'	=> 0,
+		'email_link_icons'		=> 0,
+		'pdf_link_icons'		=> 0,
+		'doc_link_icons'		=> 0,
 	);
 
 	// Populate Trestle settings with default values if they don't yet exist.

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -29,7 +29,7 @@ function trestle_admin_actions() {
  */
 function trestle_settings_defaults() {
 
-	// Trestle default key/value pairs
+	// Trestle default key/value pairs.
 	$trestle_defaults = array(
 		'layout'                => 'solid',
 		'logo_url'              => '',
@@ -46,23 +46,30 @@ function trestle_settings_defaults() {
 		'doc_link_icons' 		=> 0,
 	);
 
-	// Populate Trestle settings with default values if they don't yet exist
+	// Populate Trestle settings with default values if they don't yet exist.
 	$options = get_option( TRESTLE_SETTINGS_FIELD );
 
-	foreach ( $trestle_defaults as $k => $v ) {
-
-		// Add defaults to trestle_settings array
-		$defaults[$k] = $v;
-
-		// Update actual options if they don't yet exist
-		if ( $options && ! array_key_exists( $k, $options ) )
-			$options[$k] = $v;
+	// Set up an empty array if we're running for the first time.
+	if ( ! $options ) {
+		$options = array();
 	}
 
-	// Update options with defaults
-	update_option( TRESTLE_SETTINGS_FIELD, $options );
+	// Bail early if the settings match the defaults.
+	if ( $options === $trestle_defaults ) {
+		return;
+	}
 
-	return $defaults;
+	// Populate any defaults that are missing.
+	foreach ( $trestle_defaults as $k => $v ) {
+
+		// Check each key to only add the missing settings.
+		if ( ! array_key_exists( $k, $options ) ) {
+			$options[$k] = $v;
+		}
+	}
+
+	// Update options with defaults.
+	update_option( TRESTLE_SETTINGS_FIELD, $options );
 }
 
 add_action( 'tgmpa_register', 'trestle_register_required_plugins' );
@@ -226,7 +233,7 @@ function trestle_register_required_plugins() {
 		),
 	);
 
-	// Change this to your theme text domain, used for internationalising strings
+	// Change this to your theme text domain, used for internationalising strings.
 	$theme_text_domain = 'mightyminnow';
 
 	/**

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -19,35 +19,39 @@ function trestle_admin_actions() {
 	add_editor_style( get_stylesheet_uri() );
 }
 
-add_filter( 'genesis_theme_settings_defaults', 'trestle_custom_defaults' );
+//add_filter( 'after_setup_theme', 'trestle_settings_defaults' );
 /**
  * Sets up Trestle default settings.
  *
  * @since  1.0.0
  *
- * @param  array  $defaults  Genesis default settings.
  * @return  array  Genesis settings updated to include Trestle defaults.
  */
-function trestle_custom_defaults( $defaults ) {
+function trestle_settings_defaults() {
 
- 	// Trestle default key/value pairs
- 	$trestle_defaults = array(
-		'trestle_layout'                => 'solid',
-		'trestle_logo_url'              => '',
-		'trestle_logo_url_mobile'       => '',
-		'trestle_favicon_url'           => '',
-		'trestle_nav_primary_location'  => 'full',
-		'trestle_read_more_text'        => __( 'Read&nbsp;More&nbsp;&raquo;', 'trestle' ),
-		'trestle_revisions_number'      => 3,
-		'trestle_footer_widgets_number' => 3,
+	// Trestle default key/value pairs
+	$trestle_defaults = array(
+		'layout'                => 'solid',
+		'logo_url'              => '',
+		'logo_url_mobile'       => '',
+		'favicon_url' 			=> '',
+		'nav_primary_location'  => 'full',
+		'custom_nav_extras_text' => '',
+		'read_more_text'        => __( 'Read&nbsp;More&nbsp;&raquo;', 'trestle' ),
+		'revisions_number'      => 3,
+		'footer_widgets_number' => 3,
+		'external_link_icons'   => 0,
+		'email_link_icons' 		=> 0,
+		'pdf_link_icons' 		=> 0,
+		'doc_link_icons' 		=> 0,
 	);
 
 	// Populate Trestle settings with default values if they don't yet exist
-	$options = get_option( GENESIS_SETTINGS_FIELD );
+	$options = get_option( TRESTLE_SETTINGS_FIELD );
 
 	foreach ( $trestle_defaults as $k => $v ) {
 
-		// Add defaults to Genesis default settings array
+		// Add defaults to trestle_settings array
 		$defaults[$k] = $v;
 
 		// Update actual options if they don't yet exist
@@ -56,7 +60,7 @@ function trestle_custom_defaults( $defaults ) {
 	}
 
 	// Update options with defaults
-	update_option( GENESIS_SETTINGS_FIELD, $options );
+	update_option( TRESTLE_SETTINGS_FIELD, $options );
 
 	return $defaults;
 }

--- a/includes/admin/customizer.js
+++ b/includes/admin/customizer.js
@@ -6,8 +6,8 @@
 
 ( function( $ ) {
 
-	// Layout
-	wp.customize( 'genesis-settings[trestle_layout]', function( value ) {
+	// Layout.
+	wp.customize( 'trestle-settings[layout]', function( value ) {
 	    value.bind( function( value ) {
 
 	    	var $body = $( 'body' );
@@ -24,8 +24,8 @@
 	    });
 	});
 
-	// Custom logo
-	wp.customize( 'genesis-settings[trestle_logo_url]', function( value ) {
+	// Custom logo.
+	wp.customize( 'trestle-settings[logo_url]', function( value ) {
 	    value.bind( function( url ) {
 
 	    	var $body = $( 'body' );
@@ -42,8 +42,8 @@
 	    });
 	});
 
-	// Favicon
-	wp.customize( 'genesis-settings[trestle_favicon_url]', function( value ) {
+	// Favicon.
+	wp.customize( 'trestle-settings[favicon_url]', function( value ) {
 	    value.bind( function( url ) {
 
 	    	var $faviconElem = $( 'link[rel="Shortcut Icon"]' );
@@ -52,8 +52,8 @@
 	    });
 	});
 
-	// Primary Nav Location
-	wp.customize( 'genesis-settings[trestle_nav_primary_location]', function( value ) {
+	// Primary Nav Location.
+	wp.customize( 'trestle-settings[nav_primary_location]', function( value ) {
 	    value.bind( function( value ) {
 
 	    	var $body = $( 'body' );
@@ -75,8 +75,8 @@
 	    });
 	});
 
-	// Custom Read More Link Text
-	wp.customize( 'genesis-settings[trestle_read_more_text]', function( value )  {
+	// Custom Read More Link Text.
+	wp.customize( 'trestle-settings[read_more_text]', function( value )  {
 		value.bind( function( value ) {
 
 			$( 'a.more-link' ).html( value );
@@ -84,8 +84,8 @@
 		});
 	});
 
-	// External Links
-	wp.customize( 'genesis-settings[trestle_external_link_icons]', function( value )  {
+	// External Links.
+	wp.customize( 'trestle-settings[external_link_icons]', function( value )  {
 		value.bind( function( value ) {
 
 			var $body = $( 'body' );
@@ -99,8 +99,8 @@
 		});
 	});
 
-	// Email Links
-	wp.customize( 'genesis-settings[trestle_email_link_icons]', function( value )  {
+	// Email Links.
+	wp.customize( 'trestle-settings[email_link_icons]', function( value )  {
 		value.bind( function( value ) {
 
 			var $body = $( 'body' );
@@ -114,8 +114,8 @@
 		});
 	});
 
-	// PDF Links
-	wp.customize( 'genesis-settings[trestle_pdf_link_icons]', function( value )  {
+	// PDF Links.
+	wp.customize( 'trestle-settings[pdf_link_icons]', function( value )  {
 		value.bind( function( value ) {
 
 			var $body = $( 'body' );
@@ -129,8 +129,8 @@
 		});
 	});
 
-	// Doc Links
-	wp.customize( 'genesis-settings[trestle_doc_link_icons]', function( value )  {
+	// Doc Links.
+	wp.customize( 'trestle-settings[doc_link_icons]', function( value )  {
 		value.bind( function( value ) {
 
 			var $body = $( 'body' );

--- a/includes/admin/customizer.php
+++ b/includes/admin/customizer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Trestle Customizer Controls
+ * Trestle Customizer Controls.
  *
  * @since  1.0.0
  *
@@ -9,7 +9,7 @@
 
 add_action( 'customize_preview_init', 'trestle_customizer_preview_js' );
 /**
- * Enqueue scripts for the site preview iframe on the customizer screen
+ * Enqueue scripts for the site preview iframe on the customizer screen.
  *
  * @since  1.0.0
  */
@@ -26,19 +26,19 @@ function trestle_customizer_preview_js() {
 
 add_action( 'customize_register', 'trestle_customizer_controls' );
 /**
- * Register Trestle's controls
+ * Register Trestle's controls.
  *
  * @since  1.0.0
  *
- * @param  $wp_customize  The Customizer Object
+ * @param  $wp_customize  The Customizer Object.
  */
 function trestle_customizer_controls( $wp_customize ) {
 
 	/**
-	 * Trestle Settings Section
+	 * Trestle Settings Section.
 	 */
 
-	// Add the section
+	// Add the section.
 	$wp_customize->add_section(
 		'trestle_settings_section',
 		array(
@@ -47,11 +47,11 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 
-	// Layout
+	// Layout.
 	$wp_customize->add_setting(
-		'genesis-settings[trestle_layout]',
+		'trestle-settings[layout]',
 		array(
-			'default'		=> '',
+			'default'		=> genesis_get_option( 'layout', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -61,7 +61,7 @@ function trestle_customizer_controls( $wp_customize ) {
         'trestle_layout_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'genesis-settings[trestle_layout]',
+            'settings'  => 'trestle-settings[layout]',
             'label'     => __( 'Layout', 'trestle' ),
             'type'      => 'radio',
             'choices'   => array(
@@ -71,11 +71,11 @@ function trestle_customizer_controls( $wp_customize ) {
         )
     );
 
-	// Upload a logo
+	// Upload a logo.
     $wp_customize->add_setting(
-        'genesis-settings[trestle_logo_url]',
+        'trestle-settings[logo_url]',
         array(
-            'default'     	=> genesis_get_option( 'trestle_logo_url' ),
+            'default'     	=> genesis_get_option( 'logo_url', 'trestle-settings' ),
             'type'        	=> 'option',
             'transport'   	=> 'postMessage',
             'capability'	=> 'edit_theme_options',
@@ -88,16 +88,16 @@ function trestle_customizer_controls( $wp_customize ) {
             array(
                 'label'      => __( 'Upload a logo', 'trestle' ),
                 'section'    => 'trestle_settings_section',
-                'settings'   => 'genesis-settings[trestle_logo_url]',
+                'settings'   => 'trestle-settings[logo_url]',
             )
         )
     );
 
-    // Upload a mobile logo
+    // Upload a mobile logo.
     $wp_customize->add_setting(
-        'genesis-settings[trestle_logo_url_mobile]',
+        'trestle-settings[logo_url_mobile]',
         array(
-            'default'     	=> genesis_get_option( 'trestle_logo_url_mobile' ),
+            'default'     	=> genesis_get_option( 'logo_url_mobile', 'trestle-settings' ),
             'type'        	=> 'option',
             'transport'   	=> 'postMessage',
             'capability'	=> 'edit_theme_options',
@@ -110,16 +110,16 @@ function trestle_customizer_controls( $wp_customize ) {
             array(
                'label'      => __( 'Upload a mobile logo', 'trestle' ),
                'section'    => 'trestle_settings_section',
-               'settings'   => 'genesis-settings[trestle_logo_url_mobile]',
+               'settings'   => 'trestle-settings[logo_url_mobile]',
             )
         )
     );
 
-    // Upload a mobile logo
+    // Upload a mobile logo.
     $wp_customize->add_setting(
-        'genesis-settings[trestle_favicon_url]',
+        'trestle-settings[favicon_url]',
         array(
-            'default'     	=> genesis_get_option( 'trestle_favicon_url' ),
+            'default'     	=> genesis_get_option( 'favicon_url', 'trestle-settings' ),
             'type'        	=> 'option',
             'transport'   	=> 'postMessage',
             'capability'	=> 'edit_theme_options',
@@ -132,16 +132,16 @@ function trestle_customizer_controls( $wp_customize ) {
             array(
                'label'      => __( 'Upload a favicon', 'trestle' ),
                'section'    => 'trestle_settings_section',
-               'settings'   => 'genesis-settings[trestle_favicon_url]',
+               'settings'   => 'trestle-settings[favicon_url]',
             )
         )
     );
 
-    // Primary nav style
+    // Primary nav style.
     $wp_customize->add_setting(
-		'genesis-settings[trestle_nav_primary_location]',
+		'trestle-settings[nav_primary_location]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_nav_primary_location' ),
+			'default'		=> genesis_get_option( 'nav_primary_location', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -151,7 +151,7 @@ function trestle_customizer_controls( $wp_customize ) {
         'trestle_nav_primary_location_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'genesis-settings[trestle_nav_primary_location]',
+            'settings'  => 'trestle-settings[nav_primary_location]',
             'label'     => __( 'Menu style', 'trestle' ),
             'type'      => 'select',
             'choices'   => array(
@@ -161,11 +161,11 @@ function trestle_customizer_controls( $wp_customize ) {
         )
     );
 
-    // Primary nav extras
+    // Primary nav extras.
     $wp_customize->add_setting(
-		'genesis-settings[trestle_custom_nav_extras_text]',
+		'trestle-settings[custom_nav_extras_text]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_custom_nav_extras_text' ),
+			'default'		=> genesis_get_option( 'custom_nav_extras_text', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -175,17 +175,17 @@ function trestle_customizer_controls( $wp_customize ) {
         'trestle_custom_nav_extras_text_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'genesis-settings[trestle_custom_nav_extras_text]',
+            'settings'  => 'trestle-settings[custom_nav_extras_text]',
             'label'     => __( 'Add search to mobile navigation', 'trestle' ),
             'type'		=> 'checkbox',
         )
     );
 
-    // Blog post custom read more link text
+    // Blog post custom read more link text.
     $wp_customize->add_setting(
-		'genesis-settings[trestle_read_more_text]',
+		'trestle-settings[read_more_text]',
 		array(
-			'default'			=> genesis_get_option( 'trestle_read_more_text' ),
+			'default'			=> genesis_get_option( 'read_more_text', 'trestle-settings' ),
 			'type'				=> 'option',
 			'transport' 		=> 'postMessage',
 			'capability'     	=> 'edit_theme_options',
@@ -196,16 +196,16 @@ function trestle_customizer_controls( $wp_customize ) {
         'trestle_read_more_text_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'genesis-settings[trestle_read_more_text]',
+            'settings'  => 'trestle-settings[read_more_text]',
             'label'     => __( 'Custom read more link text', 'trestle' ),
         )
     );
 
-    // Post revisions number
+    // Post revisions number.
     $wp_customize->add_setting(
-		'genesis-settings[trestle_revisions_number]',
+		'trestle-settings[revisions_number]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_revisions_number' ),
+			'default'		=> genesis_get_option( 'revisions_number', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -215,7 +215,7 @@ function trestle_customizer_controls( $wp_customize ) {
         'trestle_revisions_number_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'genesis-settings[trestle_revisions_number]',
+            'settings'  => 'trestle-settings[revisions_number]',
             'label'     => __( 'Number of post revisions', 'trestle' ),
             'type'      => 'select',
             'choices'   => array(
@@ -235,11 +235,11 @@ function trestle_customizer_controls( $wp_customize ) {
         )
     );
 
-    // Footer Widget Areas
+    // Footer Widget Areas.
     $wp_customize->add_setting(
-		'genesis-settings[trestle_footer_widgets_number]',
+		'trestle-settings[footer_widgets_number]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_footer_widgets_number' ),
+			'default'		=> genesis_get_option( 'footer_widgets_number', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability' 	=> 'edit_theme_options',
@@ -249,7 +249,7 @@ function trestle_customizer_controls( $wp_customize ) {
         'trestle_footer_widgets_number_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'genesis-settings[trestle_footer_widgets_number]',
+            'settings'  => 'trestle-settings[footer_widgets_number]',
             'label'     => __( 'Number of footer widgets', 'trestle' ),
             'type'      => 'select',
             'choices'   => array(
@@ -264,11 +264,11 @@ function trestle_customizer_controls( $wp_customize ) {
         )
     );
 
-	// Add a label for the link icons
+	// Add a label for the link icons.
     $wp_customize->add_setting(
-		'genesis-settings[trestle_link_icons_title]',
+		'trestle-settings[link_icons_title]',
 		array(
-			'default'		=> '',
+			'default'		=> genesis_get_option( 'link_icons_title', 'trestle-settings' ),
 			'type'			=> 'option',
 			'capability'	=> 'edit_theme_options',
 		)
@@ -277,17 +277,17 @@ function trestle_customizer_controls( $wp_customize ) {
 		'trestle_link_icons_title',
 		array(
 			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'genesis-settings[trestle_link_icons_title]',
+			'settings'	=> 'trestle-settings[link_icons_title]',
 			'label'		=> __( 'Icon links', 'trestle' ),
 			'type'		=> 'hidden',
 		)
 	);
 
-	// External Link Icons
+	// External Link Icons.
 	$wp_customize->add_setting(
-		'genesis-settings[trestle_external_link_icons]',
+		'trestle-settings[external_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_external_link_icons' ),
+			'default'		=> genesis_get_option( 'external_link_icons', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -297,17 +297,17 @@ function trestle_customizer_controls( $wp_customize ) {
 		'trestle_external_link_icons',
 		array(
 			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'genesis-settings[trestle_external_link_icons]',
+			'settings'	=> 'trestle-settings[external_link_icons]',
 			'label'		=> __( 'Add icons to external links', 'trestle' ),
 			'type'		=> 'checkbox',
 		)
 	);
 
-	// E-mail Link Icons
+	// E-mail Link Icons.
 	$wp_customize->add_setting(
-		'genesis-settings[trestle_email_link_icons]',
+		'trestle-settings[email_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_email_link_icons' ),
+			'default'		=> genesis_get_option( 'email_link_icons', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -317,17 +317,17 @@ function trestle_customizer_controls( $wp_customize ) {
 		'trestle_email_link_icons',
 		array(
 			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'genesis-settings[trestle_email_link_icons]',
+			'settings'	=> 'trestle-settings[email_link_icons]',
 			'label'		=> __( 'Add icons to email links', 'trestle' ),
 			'type'		=> 'checkbox',
 		)
 	);
 
-	// PDF Link Icons
+	// PDF Link Icons.
 	$wp_customize->add_setting(
-		'genesis-settings[trestle_pdf_link_icons]',
+		'trestle-settings[pdf_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_pdf_link_icons' ),
+			'default'		=> genesis_get_option( 'pdf_link_icons', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability'	=> 'edit_theme_options',
@@ -337,17 +337,17 @@ function trestle_customizer_controls( $wp_customize ) {
 		'trestle_pdf_link_icons',
 		array(
 			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'genesis-settings[trestle_pdf_link_icons]',
+			'settings'	=> 'trestle-settings[pdf_link_icons]',
 			'label'		=> __( 'Add icons to .pdf links', 'trestle' ),
 			'type'		=> 'checkbox',
 		)
 	);
 
-	// Doc Link Icons
+	// Doc Link Icons.
 	$wp_customize->add_setting(
-		'genesis-settings[trestle_doc_link_icons]',
+		'trestle-settings[doc_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'trestle_doc_link_icons' ),
+			'default'		=> genesis_get_option( 'doc_link_icons', 'trestle-settings' ),
 			'type'			=> 'option',
 			'transport' 	=> 'postMessage',
 			'capability' 	=> 'edit_theme_options',
@@ -357,7 +357,7 @@ function trestle_customizer_controls( $wp_customize ) {
 		'trestle_doc_link_icons',
 		array(
 			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'genesis-settings[trestle_doc_link_icons]',
+			'settings'	=> 'trestle-settings[doc_link_icons]',
 			'label'		=> __( 'Add icons to .doc links', 'trestle' ),
 			'type'		=> 'checkbox',
 		)

--- a/includes/admin/customizer.php
+++ b/includes/admin/customizer.php
@@ -51,10 +51,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[layout]',
 		array(
-			'default'		=> genesis_get_option( 'layout', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'layout', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -75,10 +75,11 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
         'trestle-settings[logo_url]',
         array(
-            'default'     	=> genesis_get_option( 'logo_url', 'trestle-settings' ),
-            'type'        	=> 'option',
-            'transport'   	=> 'postMessage',
-            'capability'	=> 'edit_theme_options',
+            'default'     		=> genesis_get_option( 'logo_url', 'trestle-settings' ),
+            'type'        		=> 'option',
+            'transport'   		=> 'postMessage',
+            'capability'		=> 'edit_theme_options',
+            'sanitize_callback'	=> 'esc_url_raw',
         )
     );
     $wp_customize->add_control(
@@ -97,10 +98,11 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
         'trestle-settings[logo_url_mobile]',
         array(
-            'default'     	=> genesis_get_option( 'logo_url_mobile', 'trestle-settings' ),
-            'type'        	=> 'option',
-            'transport'   	=> 'postMessage',
-            'capability'	=> 'edit_theme_options',
+            'default'     		=> genesis_get_option( 'logo_url_mobile', 'trestle-settings' ),
+            'type'        		=> 'option',
+            'transport'   		=> 'postMessage',
+            'capability'		=> 'edit_theme_options',
+            'sanitize_callback'	=> 'esc_url_raw',
         )
     );
     $wp_customize->add_control(
@@ -119,10 +121,11 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
         'trestle-settings[favicon_url]',
         array(
-            'default'     	=> genesis_get_option( 'favicon_url', 'trestle-settings' ),
-            'type'        	=> 'option',
-            'transport'   	=> 'postMessage',
-            'capability'	=> 'edit_theme_options',
+            'default'     		=> genesis_get_option( 'favicon_url', 'trestle-settings' ),
+            'type'        		=> 'option',
+            'transport'   		=> 'postMessage',
+            'capability'		=> 'edit_theme_options',
+            'sanitize_callback'	=> 'esc_url_raw',
         )
     );
     $wp_customize->add_control(
@@ -141,10 +144,10 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
 		'trestle-settings[nav_primary_location]',
 		array(
-			'default'		=> genesis_get_option( 'nav_primary_location', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'nav_primary_location', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -155,27 +158,27 @@ function trestle_customizer_controls( $wp_customize ) {
             'label'     => __( 'Menu style', 'trestle' ),
             'type'      => 'select',
             'choices'   => array(
-                'full'  => __( 'Full Width', 'trestle' ),
-                'header'   => __( 'Header Right', 'trestle' ),
+                'full'  	=> __( 'Full Width', 'trestle' ),
+                'header'   	=> __( 'Header Right', 'trestle' ),
             )
         )
     );
 
     // Primary nav extras.
     $wp_customize->add_setting(
-		'trestle-settings[custom_nav_extras_text]',
+		'trestle-settings[search_in_nav]',
 		array(
-			'default'		=> genesis_get_option( 'custom_nav_extras_text', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'search_in_nav', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
         'trestle_custom_nav_extras_text_control',
         array(
             'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[custom_nav_extras_text]',
+            'settings'  => 'trestle-settings[search_in_nav]',
             'label'     => __( 'Add search to mobile navigation', 'trestle' ),
             'type'		=> 'checkbox',
         )
@@ -205,10 +208,10 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
 		'trestle-settings[revisions_number]',
 		array(
-			'default'		=> genesis_get_option( 'revisions_number', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'revisions_number', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -239,10 +242,10 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
 		'trestle-settings[footer_widgets_number]',
 		array(
-			'default'		=> genesis_get_option( 'footer_widgets_number', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability' 	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'footer_widgets_number', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability' 		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -268,9 +271,8 @@ function trestle_customizer_controls( $wp_customize ) {
     $wp_customize->add_setting(
 		'trestle-settings[link_icons_title]',
 		array(
-			'default'		=> genesis_get_option( 'link_icons_title', 'trestle-settings' ),
-			'type'			=> 'option',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> '',
+			'type'				=> 'option',
 		)
 	);
 	$wp_customize->add_control(
@@ -287,10 +289,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[external_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'external_link_icons', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'external_link_icons', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -307,10 +309,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[email_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'email_link_icons', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'email_link_icons', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -327,10 +329,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[pdf_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'pdf_link_icons', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability'	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'pdf_link_icons', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -347,10 +349,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[doc_link_icons]',
 		array(
-			'default'		=> genesis_get_option( 'doc_link_icons', 'trestle-settings' ),
-			'type'			=> 'option',
-			'transport' 	=> 'postMessage',
-			'capability' 	=> 'edit_theme_options',
+			'default'			=> genesis_get_option( 'doc_link_icons', 'trestle-settings' ),
+			'type'				=> 'option',
+			'transport' 		=> 'postMessage',
+			'capability' 		=> 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(

--- a/includes/admin/customizer.php
+++ b/includes/admin/customizer.php
@@ -58,90 +58,90 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-        'trestle_layout_control',
-        array(
-            'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[layout]',
-            'label'     => __( 'Layout', 'trestle' ),
-            'type'      => 'radio',
-            'choices'   => array(
-                'bubble'  => __( 'Bubble', 'trestle' ),
-                'solid'   => __( 'Solid', 'trestle' ),
-            )
-        )
-    );
+		'trestle_layout_control',
+		array(
+			'section'   => 'trestle_settings_section',
+			'settings'  => 'trestle-settings[layout]',
+			'label'     => __( 'Layout', 'trestle' ),
+			'type'      => 'radio',
+			'choices'   => array(
+				'bubble'  => __( 'Bubble', 'trestle' ),
+				'solid'   => __( 'Solid', 'trestle' ),
+			)
+		)
+	);
 
 	// Upload a logo.
-    $wp_customize->add_setting(
-        'trestle-settings[logo_url]',
-        array(
-            'default'     		=> genesis_get_option( 'logo_url', 'trestle-settings' ),
-            'type'        		=> 'option',
-            'transport'   		=> 'postMessage',
-            'capability'		=> 'edit_theme_options',
-            'sanitize_callback'	=> 'esc_url_raw',
-        )
-    );
-    $wp_customize->add_control(
-        new WP_Customize_Image_Control(
-            $wp_customize,
-            'trestle_logo_control',
-            array(
-                'label'      => __( 'Upload a logo', 'trestle' ),
-                'section'    => 'trestle_settings_section',
-                'settings'   => 'trestle-settings[logo_url]',
-            )
-        )
-    );
+	$wp_customize->add_setting(
+		'trestle-settings[logo_url]',
+		array(
+			'default'     		=> genesis_get_option( 'logo_url', 'trestle-settings' ),
+			'type'        		=> 'option',
+			'transport'   		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
+			'sanitize_callback'	=> 'esc_url_raw',
+		)
+	);
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'trestle_logo_control',
+			array(
+				'label'      => __( 'Upload a logo', 'trestle' ),
+				'section'    => 'trestle_settings_section',
+				'settings'   => 'trestle-settings[logo_url]',
+			)
+		)
+	);
 
-    // Upload a mobile logo.
-    $wp_customize->add_setting(
-        'trestle-settings[logo_url_mobile]',
-        array(
-            'default'     		=> genesis_get_option( 'logo_url_mobile', 'trestle-settings' ),
-            'type'        		=> 'option',
-            'transport'   		=> 'postMessage',
-            'capability'		=> 'edit_theme_options',
-            'sanitize_callback'	=> 'esc_url_raw',
-        )
-    );
-    $wp_customize->add_control(
-        new WP_Customize_Image_Control(
-            $wp_customize,
-            'trestle_mobile_logo_control',
-            array(
-               'label'      => __( 'Upload a mobile logo', 'trestle' ),
-               'section'    => 'trestle_settings_section',
-               'settings'   => 'trestle-settings[logo_url_mobile]',
-            )
-        )
-    );
+	// Upload a mobile logo.
+	$wp_customize->add_setting(
+		'trestle-settings[logo_url_mobile]',
+		array(
+			'default'     		=> genesis_get_option( 'logo_url_mobile', 'trestle-settings' ),
+			'type'        		=> 'option',
+			'transport'   		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
+			'sanitize_callback'	=> 'esc_url_raw',
+		)
+	);
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'trestle_mobile_logo_control',
+			array(
+			   'label'      => __( 'Upload a mobile logo', 'trestle' ),
+			   'section'    => 'trestle_settings_section',
+			   'settings'   => 'trestle-settings[logo_url_mobile]',
+			)
+		)
+	);
 
-    // Upload a mobile logo.
-    $wp_customize->add_setting(
-        'trestle-settings[favicon_url]',
-        array(
-            'default'     		=> genesis_get_option( 'favicon_url', 'trestle-settings' ),
-            'type'        		=> 'option',
-            'transport'   		=> 'postMessage',
-            'capability'		=> 'edit_theme_options',
-            'sanitize_callback'	=> 'esc_url_raw',
-        )
-    );
-    $wp_customize->add_control(
-        new WP_Customize_Image_Control(
-            $wp_customize,
-            'trestle_favicon_control',
-            array(
-               'label'      => __( 'Upload a favicon', 'trestle' ),
-               'section'    => 'trestle_settings_section',
-               'settings'   => 'trestle-settings[favicon_url]',
-            )
-        )
-    );
+	// Upload a mobile logo.
+	$wp_customize->add_setting(
+		'trestle-settings[favicon_url]',
+		array(
+			'default'     		=> genesis_get_option( 'favicon_url', 'trestle-settings' ),
+			'type'        		=> 'option',
+			'transport'   		=> 'postMessage',
+			'capability'		=> 'edit_theme_options',
+			'sanitize_callback'	=> 'esc_url_raw',
+		)
+	);
+	$wp_customize->add_control(
+		new WP_Customize_Image_Control(
+			$wp_customize,
+			'trestle_favicon_control',
+			array(
+			   'label'      => __( 'Upload a favicon', 'trestle' ),
+			   'section'    => 'trestle_settings_section',
+			   'settings'   => 'trestle-settings[favicon_url]',
+			)
+		)
+	);
 
-    // Primary nav style.
-    $wp_customize->add_setting(
+	// Primary nav style.
+	$wp_customize->add_setting(
 		'trestle-settings[nav_primary_location]',
 		array(
 			'default'			=> genesis_get_option( 'nav_primary_location', 'trestle-settings' ),
@@ -151,21 +151,21 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-        'trestle_nav_primary_location_control',
-        array(
-            'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[nav_primary_location]',
-            'label'     => __( 'Menu style', 'trestle' ),
-            'type'      => 'select',
-            'choices'   => array(
-                'full'  	=> __( 'Full Width', 'trestle' ),
-                'header'   	=> __( 'Header Right', 'trestle' ),
-            )
-        )
-    );
+		'trestle_nav_primary_location_control',
+		array(
+			'section'   => 'trestle_settings_section',
+			'settings'  => 'trestle-settings[nav_primary_location]',
+			'label'     => __( 'Menu style', 'trestle' ),
+			'type'      => 'select',
+			'choices'   => array(
+				'full'  	=> __( 'Full Width', 'trestle' ),
+				'header'   	=> __( 'Header Right', 'trestle' ),
+			)
+		)
+	);
 
-    // Primary nav extras.
-    $wp_customize->add_setting(
+	// Primary nav extras.
+	$wp_customize->add_setting(
 		'trestle-settings[search_in_nav]',
 		array(
 			'default'			=> genesis_get_option( 'search_in_nav', 'trestle-settings' ),
@@ -175,17 +175,17 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-        'trestle_custom_nav_extras_text_control',
-        array(
-            'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[search_in_nav]',
-            'label'     => __( 'Add search to mobile navigation', 'trestle' ),
-            'type'		=> 'checkbox',
-        )
-    );
+		'trestle_custom_nav_extras_text_control',
+		array(
+			'section'   => 'trestle_settings_section',
+			'settings'  => 'trestle-settings[search_in_nav]',
+			'label'     => __( 'Add search to mobile navigation', 'trestle' ),
+			'type'		=> 'checkbox',
+		)
+	);
 
-    // Blog post custom read more link text.
-    $wp_customize->add_setting(
+	// Blog post custom read more link text.
+	$wp_customize->add_setting(
 		'trestle-settings[read_more_text]',
 		array(
 			'default'			=> genesis_get_option( 'read_more_text', 'trestle-settings' ),
@@ -196,16 +196,16 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-        'trestle_read_more_text_control',
-        array(
-            'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[read_more_text]',
-            'label'     => __( 'Custom read more link text', 'trestle' ),
-        )
-    );
+		'trestle_read_more_text_control',
+		array(
+			'section'   => 'trestle_settings_section',
+			'settings'  => 'trestle-settings[read_more_text]',
+			'label'     => __( 'Custom read more link text', 'trestle' ),
+		)
+	);
 
-    // Post revisions number.
-    $wp_customize->add_setting(
+	// Post revisions number.
+	$wp_customize->add_setting(
 		'trestle-settings[revisions_number]',
 		array(
 			'default'			=> genesis_get_option( 'revisions_number', 'trestle-settings' ),
@@ -215,31 +215,31 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-        'trestle_revisions_number_control',
-        array(
-            'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[revisions_number]',
-            'label'     => __( 'Number of post revisions', 'trestle' ),
-            'type'      => 'select',
-            'choices'   => array(
-            	'-1'    => __( 'Unlimited', 'trestle' ),
-                '0'  	=> '0',
-                '1' 	=> '1',
-                '2'		=> '2',
-                '3'		=> '3',
-                '4'		=> '4',
-                '5' 	=> '5',
-                '6'		=> '6',
-                '7' 	=> '7',
-                '8' 	=> '8',
-                '9' 	=> '9',
-                '10' 	=> '10',
-            )
-        )
-    );
+		'trestle_revisions_number_control',
+		array(
+			'section'   => 'trestle_settings_section',
+			'settings'  => 'trestle-settings[revisions_number]',
+			'label'     => __( 'Number of post revisions', 'trestle' ),
+			'type'      => 'select',
+			'choices'   => array(
+				'-1'    => __( 'Unlimited', 'trestle' ),
+				'0'  	=> '0',
+				'1' 	=> '1',
+				'2'		=> '2',
+				'3'		=> '3',
+				'4'		=> '4',
+				'5' 	=> '5',
+				'6'		=> '6',
+				'7' 	=> '7',
+				'8' 	=> '8',
+				'9' 	=> '9',
+				'10' 	=> '10',
+			)
+		)
+	);
 
-    // Footer Widget Areas.
-    $wp_customize->add_setting(
+	// Footer Widget Areas.
+	$wp_customize->add_setting(
 		'trestle-settings[footer_widgets_number]',
 		array(
 			'default'			=> genesis_get_option( 'footer_widgets_number', 'trestle-settings' ),
@@ -249,26 +249,26 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-        'trestle_footer_widgets_number_control',
-        array(
-            'section'   => 'trestle_settings_section',
-            'settings'  => 'trestle-settings[footer_widgets_number]',
-            'label'     => __( 'Number of footer widgets', 'trestle' ),
-            'type'      => 'select',
-            'choices'   => array(
-                '0'  	=> '0',
-                '1' 	=> '1',
-                '2'		=> '2',
-                '3'		=> '3',
-                '4'		=> '4',
-                '5' 	=> '5',
-                '6'		=> '6',
-            )
-        )
-    );
+		'trestle_footer_widgets_number_control',
+		array(
+			'section'   => 'trestle_settings_section',
+			'settings'  => 'trestle-settings[footer_widgets_number]',
+			'label'     => __( 'Number of footer widgets', 'trestle' ),
+			'type'      => 'select',
+			'choices'   => array(
+				'0'  	=> '0',
+				'1' 	=> '1',
+				'2'		=> '2',
+				'3'		=> '3',
+				'4'		=> '4',
+				'5' 	=> '5',
+				'6'		=> '6',
+			)
+		)
+	);
 
 	// Add a label for the link icons.
-    $wp_customize->add_setting(
+	$wp_customize->add_setting(
 		'trestle-settings[link_icons_title]',
 		array(
 			'default'			=> '',

--- a/includes/admin/customizer.php
+++ b/includes/admin/customizer.php
@@ -175,7 +175,7 @@ function trestle_customizer_controls( $wp_customize ) {
 		)
 	);
 	$wp_customize->add_control(
-		'trestle_custom_nav_extras_text_control',
+		'trestle_search_in_nav_control',
 		array(
 			'section'   => 'trestle_settings_section',
 			'settings'  => 'trestle-settings[search_in_nav]',

--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -21,7 +21,7 @@ add_action( 'init', 'trestle_load_bfa' );
  */
 function trestle_load_bfa() {
 
-    // Set the library initialization args
+    // Set the library initialization args.
     $args = array(
 			'version'             => 'latest',
 			'minified'            => true,
@@ -49,23 +49,23 @@ add_action( 'wp_enqueue_scripts', 'trestle_header_actions' );
  */
 function trestle_header_actions() {
 
-	// Google fonts
+	// Google fonts.
 	wp_enqueue_style( 'theme-google-fonts', '//fonts.googleapis.com/css?family=Lato:300,400,700' );
 
-	// Theme jQuery
+	// Theme jQuery.
 	wp_enqueue_script( 'theme-jquery', get_stylesheet_directory_uri() . '/includes/js/theme-jquery.js', array( 'jquery' ), CHILD_THEME_VERSION, true );
 
-	// Get WP uploads directory
+	// Get WP uploads directory.
 	$upload_dir = wp_upload_dir();
 	$upload_path = $upload_dir['basedir'];
 	$upload_url = $upload_dir['baseurl'];
 
-	// Custom CSS (if it exists)
+	// Custom CSS (if it exists).
 	$custom_css_file = '/trestle/custom.css';
 	if ( is_readable( $upload_path . $custom_css_file ) )
 		wp_enqueue_style( 'trestle-custom-css', $upload_url . $custom_css_file );
 
-	// Custom jQuery (if it exists)
+	// Custom jQuery (if it exists).
 	$custom_js_file = '/trestle/custom.js';
 	if ( is_readable( $upload_path . $custom_js_file ) )
 		wp_enqueue_script( 'trestle-custom-jquery', $upload_url . $custom_js_file, array( 'jquery' ), CHILD_THEME_VERSION, true );
@@ -83,7 +83,7 @@ add_filter( 'genesis_pre_load_favicon', 'trestle_do_custom_favicon' );
  * @return  string  Custom favicon URL (if specified), or the default URL.
  */
 function trestle_do_custom_favicon( $favicon_url ) {
-	return genesis_get_option( 'trestle_favicon_url' ) ? genesis_get_option( 'trestle_favicon_url' ) : $favicon_url;
+	return genesis_get_option( 'favicon_url', 'trestle-settings' ) ? genesis_get_option( 'favicon_url', 'trestle-settings' ) : $favicon_url;
 }
 
 /*===========================================
@@ -101,33 +101,33 @@ add_filter( 'body_class', 'trestle_body_classes' );
  */
 function trestle_body_classes( $classes ) {
 
-	// Add 'no-jquery' class to be removed by jQuery if enabled
+	// Add 'no-jquery' class to be removed by jQuery if enabled.
 	$classes[] = 'no-jquery';
 
-	// Add 'bubble' class
-	if ( 'bubble' == genesis_get_option( 'trestle_layout' ) )
+	// Add 'bubble' class.
+	if ( 'bubble' == genesis_get_option( 'layout', 'trestle-settings' ) )
 		$classes[] = 'bubble';
 
-	// Add link icon classes
-	if ( genesis_get_option( 'trestle_external_link_icons' ) )
+	// Add link icon classes.
+	if ( genesis_get_option( 'external_link_icons', 'trestle-settings' ) )
 		$classes[] = 'external-link-icons';
-	if ( genesis_get_option( 'trestle_email_link_icons' ) )
+	if ( genesis_get_option( 'email_link_icons', 'trestle-settings' ) )
 		$classes[] = 'email-link-icons';
-	if ( genesis_get_option( 'trestle_pdf_link_icons' ) )
+	if ( genesis_get_option( 'pdf_link_icons', 'trestle-settings' ) )
 		$classes[] = 'pdf-link-icons';
-	if ( genesis_get_option( 'trestle_doc_link_icons' ) )
+	if ( genesis_get_option( 'doc_link_icons', 'trestle-settings' ) )
 		$classes[] = 'doc-link-icons';
 
-	// Add menu style class
-	if ( genesis_get_option( 'trestle_nav_primary_location' ) )
-		$classes[] = 'nav-primary-location-' . esc_attr( genesis_get_option( 'trestle_nav_primary_location' ) );
+	// Add menu style class.
+	if ( genesis_get_option( 'nav_primary_location', 'trestle-settings' ) )
+		$classes[] = 'nav-primary-location-' . esc_attr( genesis_get_option( 'nav_primary_location', 'trestle-settings' ) );
 
-	// Add footer widget number class
-	if ( genesis_get_option( 'trestle_footer_widgets_number' ) )
-		$classes[] = 'footer-widgets-number-' . esc_attr( genesis_get_option( 'trestle_footer_widgets_number' ) );
+	// Add footer widget number class.
+	if ( genesis_get_option( 'footer_widgets_number', 'trestle-settings' ) )
+		$classes[] = 'footer-widgets-number-' . esc_attr( genesis_get_option( 'footer_widgets_number', 'trestle-settings' ) );
 
-	// Add logo class
-	if ( genesis_get_option( 'trestle_logo_url' ) || genesis_get_option( 'trestle_logo_url_mobile' ) )
+	// Add logo class.
+	if ( genesis_get_option( 'logo_url', 'trestle-settings' ) || genesis_get_option( 'logo_url_mobile', 'trestle-settings' ) )
 		$classes[] = 'has-logo';
 
 	return $classes;
@@ -147,17 +147,17 @@ add_filter( 'genesis_seo_title', 'trestle_do_logos', 10, 3 );
  */
 function trestle_do_logos( $title, $inside, $wrap ) {
 
-	$logo_url = genesis_get_option( 'trestle_logo_url' );
-	$logo_url_mobile = genesis_get_option( 'trestle_logo_url_mobile' );
+	$logo_url = genesis_get_option( 'logo_url', 'trestle-settings' );
+	$logo_url_mobile = genesis_get_option( 'logo_url_mobile', 'trestle-settings' );
 	$logo_html = '';
 
-	// Regular logo
+	// Regular logo.
 	if ( $logo_url ) {
 
-		// Default logo class
+		// Default logo class.
 		$classes = array('logo-full');
 
-		// If no mobile logo is specified, make regular logo act as mobile logo too
+		// If no mobile logo is specified, make regular logo act as mobile logo too.
 		if( ! $logo_url_mobile )
 			$classes[] = 'show';
 
@@ -168,13 +168,13 @@ function trestle_do_logos( $title, $inside, $wrap ) {
 		);
 	}
 
-	// Mobile logo
+	// Mobile logo.
 	if ( $logo_url_mobile ) {
 
-		// Default mobile logo class
+		// Default mobile logo class.
 		$classes = array('logo-mobile');
 
-		// If no regular logo is specified, make mobile logo act as regular logo too
+		// If no regular logo is specified, make mobile logo act as regular logo too.
 		if( ! $logo_url )
 			$classes[] = 'show';
 
@@ -193,11 +193,11 @@ function trestle_do_logos( $title, $inside, $wrap ) {
 		);
 	}
 
-	// Build the title
+	// Build the title.
 	$title  = genesis_html5() ? sprintf( "<{$wrap} %s>", genesis_attr( 'site-title' ) ) : sprintf( '<%s id="title">%s</%s>', $wrap, $inside, $wrap );
 	$title .= genesis_html5() ? "{$inside}</{$wrap}>" : '';
 
-	// Echo (filtered)
+	// Echo (filtered).
 	return $title;
 }
 
@@ -214,7 +214,7 @@ add_action( 'init', 'trestle_nav_primary_location' );
  */
 function trestle_nav_primary_location() {
 
-	if ( 'header' == genesis_get_option( 'trestle_nav_primary_location' ) ) {
+	if ( 'header' == genesis_get_option( 'nav_primary_location', 'trestle-settings' ) ) {
 		remove_action( 'genesis_after_header', 'genesis_do_nav' );
 		add_action( 'genesis_header', 'genesis_do_nav', 12 );
 	}
@@ -233,7 +233,7 @@ add_filter( 'wp_nav_menu_items', 'trestle_custom_nav_extras', 10, 2 );
  */
 function trestle_custom_nav_extras( $nav_items, stdClass $menu_args ) {
 
-	if ( 'primary' == $menu_args->theme_location && genesis_get_option( 'trestle_custom_nav_extras_text' ) ) {
+	if ( 'primary' == $menu_args->theme_location && genesis_get_option( 'custom_nav_extras_text', 'trestle-settings' ) ) {
 		return $nav_items . '<li class="right custom">' . get_search_form( false ) . '</li>';
 	}
 
@@ -256,7 +256,7 @@ add_filter( 'wp_revisions_to_keep', 'trestle_update_revisions_number', 10, 2 );
  */
 function trestle_update_revisions_number( $num ) {
 
-	$trestle_revisions_number = esc_attr( genesis_get_option( 'trestle_revisions_number' ) );
+	$trestle_revisions_number = esc_attr( genesis_get_option( 'revisions_number', 'trestle-settings' ) );
 
 	if ( isset( $trestle_revisions_number ) )
 		return $trestle_revisions_number;
@@ -264,61 +264,9 @@ function trestle_update_revisions_number( $num ) {
 	return $num;
 }
 
-add_action( 'the_post', 'trestle_post_info_meta', 5 );
-/**
- * Manually controls display of post info/meta for all post types.
- *
- * @since 1.0.0
- *
- * @see trestle_set_page_post_type()
- * @global object $post The current $post object.
- */
-function trestle_post_info_meta() {
-
-	if ( ! is_admin() && in_the_loop() && genesis_get_option( 'trestle_manual_post_info_meta' ) ) {
-
-		global $post;
-
-		// Get post type
-		$post_type = get_post_type( $post->ID );
-
-		// Remove all Post Info & Meta
-		remove_action( 'genesis_entry_header', 'genesis_post_info', 12 );
-		remove_action( 'genesis_entry_footer', 'genesis_post_meta' );
-
-		// Single
-		if ( is_singular() ) {
-			$single_info_option = 'trestle_post_info_' . $post_type . '_single';
-			$single_meta_option = 'trestle_post_meta_' . $post_type . '_single';
-
-			// Post Info
-			if ( genesis_get_option( $single_info_option ) )
-				add_action( 'genesis_entry_header', 'genesis_post_info', 12 );
-
-			// Post Meta
-			if ( genesis_get_option( $single_meta_option ) )
-				add_action( 'genesis_entry_footer', 'genesis_post_meta' );
-		}
-
-		// Archive
-		if ( ! is_singular() ) {
-			$archive_info_option = 'trestle_post_info_' . $post_type . '_archive';
-			$archive_meta_option = 'trestle_post_meta_' . $post_type . '_archive';
-
-			// Post Info
-			if ( genesis_get_option( $archive_info_option ) )
-				add_action( 'genesis_entry_header', 'genesis_post_info', 12 );
-
-			// Post Meta
-			if ( genesis_get_option( $archive_meta_option ) )
-				add_action( 'genesis_entry_footer', 'genesis_post_meta' );
-		}
-	}
-}
-
 add_filter( 'genesis_get_image_default_args', 'trestle_featured_image_fallback' );
 /**
- * Unset Genesis default featured image fallback of 'first-attached'
+ * Unset Genesis default featured image fallback of 'first-attached'.
  *
  * This function prevents Genesis' default behavior of displaying
  * the 'first-attached' image as a post's featured image (in archive)
@@ -326,8 +274,8 @@ add_filter( 'genesis_get_image_default_args', 'trestle_featured_image_fallback' 
  *
  * @since 1.0.0
  *
- * @param array $args Default Genesis image args
- * @return array Updated image args
+ * @param array $args Default Genesis image args.
+ * @return array Updated image args.
  */
 function trestle_featured_image_fallback( $args ) {
 
@@ -354,8 +302,8 @@ add_filter( 'the_content_more_link', 'trestle_read_more_link' );
  */
 function trestle_read_more_link( $default_text ) {
 
-	// Get Trestle custom "read more" link text
-	$custom_text = esc_attr( genesis_get_option( 'trestle_read_more_text' ) );
+	// Get Trestle custom "read more" link text.
+	$custom_text = esc_attr( genesis_get_option( 'read_more_text', 'trestle-settings' ) );
 
 	if ( $custom_text ) {
 		return '&hellip;&nbsp;<a class="more-link" title="' . $custom_text . '" href="' . get_permalink() . '">' . $custom_text . '</a>';

--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -21,8 +21,8 @@ add_action( 'init', 'trestle_load_bfa' );
  */
 function trestle_load_bfa() {
 
-    // Set the library initialization args.
-    $args = array(
+	// Set the library initialization args.
+	$args = array(
 			'version'             => 'latest',
 			'minified'            => true,
 			'remove_existing_fa'  => false,
@@ -30,10 +30,10 @@ function trestle_load_bfa() {
 			'load_admin_styles'   => true,
 			'load_shortcode'      => true,
 			'load_tinymce_plugin' => true,
-    );
+	);
 
-    // Initialize the Better Font Awesome Library.
-    Better_Font_Awesome_Library::get_instance( $args );
+	// Initialize the Better Font Awesome Library.
+	Better_Font_Awesome_Library::get_instance( $args );
 
 }
 

--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -233,7 +233,7 @@ add_filter( 'wp_nav_menu_items', 'trestle_custom_nav_extras', 10, 2 );
  */
 function trestle_custom_nav_extras( $nav_items, stdClass $menu_args ) {
 
-	if ( 'primary' == $menu_args->theme_location && genesis_get_option( 'custom_nav_extras_text', 'trestle-settings' ) ) {
+	if ( 'primary' == $menu_args->theme_location && genesis_get_option( 'search_in_nav', 'trestle-settings' ) ) {
 		return $nav_items . '<li class="right custom">' . get_search_form( false ) . '</li>';
 	}
 

--- a/includes/shortcodes/shortcodes.php
+++ b/includes/shortcodes/shortcodes.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Trestle shortcodes
+ * Trestle shortcodes.
  *
  * @since 1.0.0
  *
@@ -11,9 +11,9 @@
  * Shortcodes
 ===========================================*/
 
-add_filter('the_content', 'trestle_shortcode_empty_paragraph_fix');
+add_filter( 'the_content', 'trestle_shortcode_empty_paragraph_fix' );
 /**
- * Fix for empty <p> tags around shortcodes
+ * Fix for empty <p> tags around shortcodes.
  *
  * @since  1.0.0
  *
@@ -28,14 +28,14 @@ function trestle_shortcode_empty_paragraph_fix( $content ) {
         ']<br />' => ']'
         );
 
-    $content = strtr($content, $array);
+    $content = strtr( $content, $array );
 
     return $content;
 }
 
 add_shortcode( 'col', 'trestle_column' );
 /**
- * Columns
+ * Columns.
  *
  * Example:
  * [col class="one-half first no-list-margin"] Contents [/col]
@@ -58,7 +58,7 @@ function trestle_column( $atts, $content = null ) {
 
 add_shortcode( 'button', 'trestle_button' );
 /**
- * Button
+ * Button.
  *
  * Example: [button href="url" title="title" target="target" class="class"]Text[/button]
  *
@@ -78,7 +78,7 @@ function trestle_button( $atts, $content = null ) {
 
 add_shortcode( 'date', 'trestle_date' );
 /**
- * Date
+ * Date.
  *
  * Example: [date format="M d, Y"]
  *
@@ -100,7 +100,7 @@ function trestle_date( $atts ) {
 
 add_shortcode( 'blockquote', 'trestle_blockquote_shortcode' );
 /**
- * Blockquote
+ * Blockquote.
  *
  * Example: [blockquote citation=""]Content[/blockquote]
  *

--- a/includes/widget-areas/widget-areas.php
+++ b/includes/widget-areas/widget-areas.php
@@ -1,16 +1,16 @@
 <?php
 
 /**
- * Trestle widget area registration and functionality
- *  
+ * Trestle widget area registration and functionality.
+ *
  * @since  1.0.0
- * 
+ *
  * @package Trestle
  */
 
 //add_action( 'widgets_init', 'trestle_register_widget_areas' );
 /**
- * Register custom widget areas
+ * Register custom widget areas.
  *
  * @since 1.0.0
  */


### PR DESCRIPTION
Also includes:
- More consistent inline documentation
- Renaming of the 'custom_nav_extras_text' setting to 'search_in_nav'
- Changes to how we set default settings