### PR TITLE
Fix for jQuery UI datepicker CSS issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -1962,6 +1962,19 @@ Site Footer
 General Components
 ---------------------------------------------------------------------------------------------------- */
 
+/* jQuery UI
+--------------------------------------------- */
+
+/* Datepicker */
+
+table.ui-datepicker-calendar {
+	line-height: 1;
+}
+
+.ui-datepicker select {
+	width: auto;
+}
+
 /* Search Form
 --------------------------------------------- */
 


### PR DESCRIPTION
This gets us most of the way to a fix on #11. Both Gravity Forms and WP Views include styling for the jQuery UI datepicker and they clash pretty bad, but this fixes the issues with our default styling in Trestle.